### PR TITLE
➕ Add read params functions (including .json.gz)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reskit
 Title: Nice selection box of goodies for hobnobbing with NHP model results
-Version: 0.2.2
+Version: 0.2.1
 Authors@R:
     person(
         "Fran", "Barton",
@@ -18,7 +18,7 @@ RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Depends: R (>= 4.5.0)
 Imports:
-    azkit (>= 0.2.4),
+    azkit (>= 0.2.3),
     AzureStor,
     cli,
     dplyr,
@@ -27,6 +27,7 @@ Imports:
     ggplot2,
     glue,
     gt,
+    jsonlite,
     purrr,
     rlang,
     scales,

--- a/R/read_zipped_results_params.R
+++ b/R/read_zipped_results_params.R
@@ -1,0 +1,26 @@
+read_zipped_results_params <- function(container, path) {
+  container |>
+    azkit::read_azure_jsongz(path, opts = list(obj_of_arrs_to_df = FALSE)) |>
+    purrr::pluck("params") |>
+    purrr::modify_tree(leaf = \(x) if (length(x) > 1) as.list(x) else x)
+}
+
+read_results_params <- function(container, path) {
+  container |>
+    azkit::read_azure_json(path, opts = list(obj_of_arrs_to_df = FALSE)) |>
+    purrr::modify_tree(leaf = \(x) if (length(x) > 1) as.list(x) else x)
+}
+
+
+read_zipped_results_params <- function(container, path) {
+  azkit::read_azure_file(container, path) |>
+    jsonlite::parse_gzjson_raw(simplifyVector = FALSE) |>
+    purrr::pluck("params")
+}
+
+read_results_params <- function(container, path) {
+  withr::with_tempfile("dl", {
+    AzureStor::download_blob(container, path, dest = dl)
+    jsonlite::fromJSON(dl, simplifyVector = FALSE)
+  })
+}


### PR DESCRIPTION
Should close #58

There are two versions of each function supplied:

- 1 using the `azkit` `read_*` functions, which have minimal differences in output compared to the current standard / expected output (eg numeric vectors rather than lists)
- 1 using the `jsonlite` package, which have negligible differences in output compared to the current standard / expected output (eg numbers represented as integers rather than doubles)

This PR is here as an example of how these functions could be adopted in reskit.
But it is not currently ready to review and merge, because:

a) there are two identically-named versions of each function, so a choice has to be made as to which approach to take
b) it is possible we will move away from ever needing to read in a `.json.gz` file so these will be obsolete

See also: discussion and background [here](https://github.com/The-Strategy-Unit/nhp_tagged_runs_params/pull/20) and [here](https://github.com/The-Strategy-Unit/nhp_reskit/issues/58)