### PR TITLE
:dancer: Fix shim_basic and bump to v0.4.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reskit
 Title: Nice selection box of goodies for hobnobbing with NHP model results
-Version: 0.4.3
+Version: 0.4.4
 Authors@R:
     c(person(
         "Fran", "Barton",
@@ -28,7 +28,7 @@ RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Depends: R (>= 4.5.0)
 Imports:
-    azkit (>= 0.2.4),
+    azkit (>= 0.2.5),
     AzureStor,
     cli,
     dplyr,

--- a/R/shim_results.R
+++ b/R/shim_results.R
@@ -12,7 +12,11 @@ shim_results <- function(results) {
     purrr::map(ensure_character_cols)
 }
 
-shim_basic <- \(df) tidyr::unnest_longer(df, "model_runs", "value", "model_run")
+shim_basic <- function(df) {
+  df |>
+    dplyr::select(!tidyselect::any_of("value")) |>
+    tidyr::unnest_longer("model_runs", "value", "model_run")
+}
 
 
 shim_with_baseline <- function(df) {


### PR DESCRIPTION
Allows `step_counts` table to contain an initial `value` column (the principal value) which we then remove.
I think the new `shim_basic()` still works OK when embedded in `shim_with_baseline`