### PR TITLE
:scissors: Exclude old cols median, principal, pi from shimmed results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reskit
 Title: Nice selection box of goodies for hobnobbing with NHP model results
-Version: 0.4.5
+Version: 0.4.6
 Authors@R:
     c(person(
         "Fran", "Barton",

--- a/R/shim_results.R
+++ b/R/shim_results.R
@@ -14,7 +14,9 @@ shim_results <- function(results) {
 
 shim_basic <- function(df) {
   df |>
-    dplyr::select(!tidyselect::any_of("value")) |>
+    dplyr::select(
+      !tidyselect::any_of(c("value", "principal", "median", "lwr_pi", "upr_pi"))
+    ) |>
     tidyr::unnest_longer("model_runs", "value", "model_run")
 }
 
@@ -31,6 +33,12 @@ shim_with_baseline <- function(df) {
 
 
 ensure_character_cols <- function(df) {
-  these <- c("age_group", "attendance_category", "tretspef", "tretspef_grouped", "los_group")
+  these <- c(
+    "age_group",
+    "attendance_category",
+    "tretspef",
+    "tretspef_grouped",
+    "los_group"
+  )
   dplyr::mutate(df, dplyr::across(tidyselect::any_of(these), as.character))
 }


### PR DESCRIPTION
The old columns ` c("principal", "median", "lwr_pi", "upr_pi")` should not be allowed to persist in the shimmed results. They are not present in the new parquet format, and leaving them in causes duplicate columns in the later {reskit} steps.

Have bumped version  🤕 

Note: Diff in `ensure_character_cols()` is just due to running `air format`