### PR TITLE
Do not aggregate pods for the waterfall

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reskit
 Title: Nice selection box of goodies for hobnobbing with NHP model results
-Version: 1.0.2
+Version: 1.0.3
 Authors@R:
     c(person(
         "Fran", "Barton",

--- a/R/change_factor_data.R
+++ b/R/change_factor_data.R
@@ -19,7 +19,7 @@ compile_change_factor_data <- function(
   activity_type = c("ip", "op", "aae"),
   pods = NULL,
   sites = NULL,
-  pod_lookup = get_principal_pods(),
+  pod_lookup = get_detailed_pods(),
   tpma_lookup = get_tpma_label_lookup(),
   include_baseline = TRUE
 ) {
@@ -145,8 +145,7 @@ prepare_principal_cf_data <- function(
   bsline_filtered <- dplyr::filter(dat, .data[["change_factor"]] != "baseline")
   dat_prepared <- if (include_baseline) dat else bsline_filtered
   dat_prepared |>
-    dplyr::filter(dplyr::if_any("value", \(x) x != 0)) |>
-    combine_all_aae_pods() |>
+    dplyr::filter(dplyr::if_any("model_run", \(x) x != 0)) |>
     inner_join_for_labels(pod_lookup) |>
     relabel_pods() |>
     dplyr::left_join(tpma_lookup, "strategy") |>

--- a/man/compile_change_factor_data.Rd
+++ b/man/compile_change_factor_data.Rd
@@ -10,7 +10,7 @@ compile_change_factor_data(
   activity_type = c("ip", "op", "aae"),
   pods = NULL,
   sites = NULL,
-  pod_lookup = get_principal_pods(),
+  pod_lookup = get_detailed_pods(),
   tpma_lookup = get_tpma_label_lookup(),
   include_baseline = TRUE
 )


### PR DESCRIPTION
Close #167 (by doing as little as possible).

* Removed A&E POD aggregation when wrangling data ahead of creating waterfall charts.
* Used the detailed POD lookup as default to allow matching of disaggregated A&E PODs.
* Filtered out the zeroth model run rather than zero values.
* Bumped v1.0.3.

For the scenario that triggered #167, I've checked locally that (a) the A&E baseline values match between the summary POD table and waterfall, and (b) the behaviour of the outputs app is as expected when using {reskit} from this branch.

Edit: performed further checks on older v5 releases, as noted [in the corresponding outputs-app issue](https://github.com/The-Strategy-Unit/nhp_outputs/issues/463).